### PR TITLE
feat: initial module implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 <!-- Update the title -->
-# Terraform Modules Template Project
+# Terraform IBM S2S Auth
 
 <!--
 Update status and "latest release" badges:
   1. For the status options, see https://github.ibm.com/GoldenEye/documentation/blob/master/status.md
   2. Update the "latest release" badge to point to the correct module's repo. Replace "module-template" in two places.
 -->
-[![Incubating (Not yet consumable)](https://img.shields.io/badge/status-Incubating%20(Not%20yet%20consumable)-red)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+[![Stable (Adopted)](https://img.shields.io/badge/Status-Stable%20(Adopted)-yellowgreen?style=plastic)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
 [![latest release](https://img.shields.io/github/v/release/terraform-ibm-modules/terraform-ibm-s2s-auth?logo=GitHub&sort=semver)](https://github.com/terraform-ibm-modules/terraform-ibm-s2s-auth/releases/latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-<!-- Add a description of module(s) in this repo -->
-TODO: Replace me with description of the module(s) in this repo
-
+This module is responsible for generating authorization policies and CBR rules that enable access permissions and restrictions between a source service and a target service
 
 <!-- Below content is automatically populated via pre-commit hook -->
 <!-- BEGIN OVERVIEW HOOK -->
@@ -49,38 +47,41 @@ unless real values don't help users know what to change.
 -->
 
 ```hcl
-
+module "service_auth_cbr_rules" {
+  # Replace "main" with a GIT release version to lock into a specific release
+  source                = "git::https://github.com/terraform-ibm-modules/terraform-ibm-s2s-auth.git?ref=main"
+  service_map           = [
+    {
+        "description"= "This is a test auth policy",
+        "enforcement_mode"= "report",
+        "roles"= [
+            "Reader"
+        ],
+        "source_resource_instance_id"= "<source_resource_instance_id>",
+        "source_service_name"= "cloud-object-storage",
+        "target_resource_instance_id"= "<target_resource_instance_id>",
+        "target_service_name"= "kms"
+    },
+    {
+        "description"= "This is a test auth policy",
+        "enforcement_mode"= "report",
+        "roles"= [
+            "Reader"
+        ],
+        "source_rg"= "<source_rg>",
+        "source_service_name"= "containers-kubernetes",
+        "target_rg"= "<target_rg>",
+        "target_service_name"= "kms"
+    }
+  ]
+}
 ```
 
 ### Required IAM access policies
 
-<!-- PERMISSIONS REQUIRED TO RUN MODULE
-If this module requires permissions, uncomment the following block and update
-the sample permissions, following the format.
-Replace the sample Account and IBM Cloud service names and roles with the
-information in the console at
-Manage > Access (IAM) > Access groups > Access policies.
--->
-
-<!--
 You need the following permissions to run this module.
 
-- Account Management
-    - **Sample Account Service** service
-        - `Editor` platform access
-        - `Manager` service access
-    - IAM Services
-        - **Sample Cloud Service** service
-            - `Administrator` platform access
--->
-
-<!-- NO PERMISSIONS FOR MODULE
-If no permissions are required for the module, uncomment the following
-statement instead the previous block.
--->
-
-<!-- No permissions are needed to run this module.-->
-
+* You must have access to the target service to create an authorization between services. You can grant only the level of access that you have as a user of the target service. For example, if you have viewer access on the target service, you can assign only the viewer role for the authorization.
 
 <!-- Below content is automatically populated via pre-commit hook -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -89,22 +90,36 @@ statement instead the previous block.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, <1.6.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1 |
 
 ### Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cbr_rules"></a> [cbr\_rules](#module\_cbr\_rules) | terraform-ibm-modules/cbr/ibm//modules/cbr-service-profile | 1.12.1 |
 
 ### Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [ibm_iam_authorization_policy.auth_policies](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_authorization_policy) | resource |
 
 ### Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cbr_target_service_details"></a> [cbr\_target\_service\_details](#input\_cbr\_target\_service\_details) | Details of the target service for which the rule has to be created | <pre>list(object({<br>    target_service_name = string<br>    target_rg           = optional(string)<br>    enforcement_mode    = string<br>    tags                = optional(list(string))<br>  }))</pre> | `[]` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to append when creating CBR zones and CBR rules | `string` | `null` | no |
+| <a name="input_service_map"></a> [service\_map](#input\_service\_map) | Map of source service and the corresponding target service details | <pre>list(object({<br>    source_service_name         = string<br>    target_service_name         = string<br>    roles                       = list(string)<br>    description                 = optional(string, null)<br>    source_resource_instance_id = optional(string, null)<br>    target_resource_instance_id = optional(string, null)<br>    source_resource_group_id    = optional(string, null)<br>    target_resource_group_id    = optional(string, null)<br>  }))</pre> | `[]` | no |
+| <a name="input_zone_service_ref_list"></a> [zone\_service\_ref\_list](#input\_zone\_service\_ref\_list) | Service reference for the zone creation | `list(string)` | `[]` | no |
+| <a name="input_zone_vpc_crn_list"></a> [zone\_vpc\_crn\_list](#input\_zone\_vpc\_crn\_list) | VPC CRN for the zones | `list(string)` | `[]` | no |
 
 ### Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_auth_policies"></a> [auth\_policies](#output\_auth\_policies) | Authorizations created |
+| <a name="output_cbr_rules"></a> [cbr\_rules](#output\_cbr\_rules) | CBR Rules created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- Leave this section as is so that your module has a link to local development environment set up steps for contributors to follow -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -7,5 +7,7 @@ The text below should describe exactly what resources are provisioned / configur
 -->
 
 An end-to-end basic example that will provision the following:
+
 - A new resource group if one is not passed in.
-- A new Cloud Object Storage instance.
+- An authorization policy for databases-for-postgresql -> kms.
+- A cbr rule for kms in the resource group.

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -2,17 +2,7 @@
 # Outputs
 ########################################################################################################################
 
-output "cos_instance_id" {
-  description = "COS instance id"
-  value       = ibm_resource_instance.cos_instance.id
-}
-
-output "resource_group_name" {
-  description = "Resource group name"
-  value       = module.resource_group.resource_group_name
-}
-
-output "resource_group_id" {
-  description = "Resource group ID"
-  value       = module.resource_group.resource_group_id
+output "service_auth_cbr_rules" {
+  description = "Details of rules created"
+  value       = module.service_auth_cbr_rules
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -17,17 +17,11 @@ variable "region" {
 variable "prefix" {
   type        = string
   description = "Prefix to append to all resources created by this example"
-  default     = "basic"
+  default     = "basic-s2s"
 }
 
 variable "resource_group" {
   type        = string
   description = "The name of an existing resource group to provision resources in to. If not set a new resource group will be created using the prefix variable"
   default     = null
-}
-
-variable "resource_tags" {
-  type        = list(string)
-  description = "Optional list of tags to be added to created resources"
-  default     = []
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.49.0"
+      version = "1.56.1"
     }
   }
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -2,3 +2,11 @@
 
 <!-- There is a pre-commit hook that will take the title of each example add include it in the repos main README.md  -->
 <!-- Add text below should describe exactly what resources are provisioned / configured by the example  -->
+
+An example that creates authentication policies and context based restrictions
+
+This example uses the IBM Cloud terraform provider to:
+
+- Create resource groups if not provided
+- Create a Cloud Object Storage and Key protect instance instance
+- Create auth policies and CBR rules for the newly created services

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,3 +1,95 @@
 ##############################################################################
 # Complete example
 ##############################################################################
+
+##############################################################################
+# Resource Group
+##############################################################################
+
+module "resource_group" {
+  source  = "terraform-ibm-modules/resource-group/ibm"
+  version = "1.1.0"
+  # if an existing resource group is not set (null) create a new one using prefix
+  resource_group_name          = var.resource_group == null ? "${var.prefix}-resource-group" : null
+  existing_resource_group_name = var.resource_group
+}
+
+# Create COS instance
+module "cos_instance" {
+  source                 = "terraform-ibm-modules/cos/ibm"
+  version                = "6.12.2"
+  cos_instance_name      = "${var.prefix}-cos"
+  kms_encryption_enabled = false
+  retention_enabled      = false
+  resource_group_id      = module.resource_group.resource_group_id
+  bucket_name            = "${var.prefix}-cos-bucket"
+}
+
+# Create Key Protect instance
+module "key_protect_instance" {
+  source            = "terraform-ibm-modules/key-protect/ibm"
+  version           = "2.3.1"
+  key_protect_name  = "${var.prefix}-key-protect"
+  resource_group_id = module.resource_group.resource_group_id
+  plan              = "tiered-pricing"
+  region            = var.region
+  tags              = var.resource_tags
+}
+
+resource "ibm_is_vpc" "vpc_instance" {
+  name           = "${var.prefix}-vpc"
+  resource_group = module.resource_group.resource_group_id
+  tags           = var.resource_tags
+}
+
+# generate a service_map
+locals {
+  service_map = [
+    {
+      source_service_name         = "cloud-object-storage"
+      target_service_name         = "kms"
+      roles                       = ["Reader"]
+      description                 = "This is a test policy"
+      source_resource_instance_id = module.cos_instance.cos_instance_id
+      target_resource_instance_id = module.key_protect_instance.key_protect_guid
+      source_resource_group_id    = null
+      target_resource_group_id    = null
+    },
+    {
+      source_service_name         = "cloud-object-storage"
+      target_service_name         = "kms"
+      roles                       = ["Reader"]
+      description                 = "This is a test policy"
+      source_resource_instance_id = null
+      target_resource_instance_id = module.key_protect_instance.key_protect_guid
+      source_resource_group_id    = module.resource_group.resource_group_id
+      target_resource_group_id    = null
+    },
+    {
+      source_service_name         = "cloud-object-storage"
+      target_service_name         = "kms"
+      roles                       = ["Reader"]
+      description                 = "This is a test policy"
+      source_resource_instance_id = module.cos_instance.cos_instance_id
+      target_resource_instance_id = null
+      source_resource_group_id    = null
+      target_resource_group_id    = module.resource_group.resource_group_id
+    }
+  ]
+  cbr_target_service_details = [
+    {
+      target_service_name = "kms"
+      target_rg           = module.resource_group.resource_group_id
+      enforcement_mode    = var.enforcement_mode
+    }
+  ]
+}
+
+module "service_auth_cbr_rules" {
+  source                     = "../.."
+  service_map                = local.service_map
+  cbr_target_service_details = local.cbr_target_service_details
+  prefix                     = var.prefix
+  zone_vpc_crn_list          = [ibm_is_vpc.vpc_instance.crn]
+  zone_service_ref_list      = ["cloud-object-storage"]
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -2,22 +2,17 @@
 # Outputs
 ##############################################################################
 
-output "region" {
-  description = "The region all resources were provisioned in"
-  value       = var.region
+output "cos_instance" {
+  description = "COS instance"
+  value       = module.resource_group.resource_group_id
 }
 
-output "prefix" {
-  description = "The prefix used to name all provisioned resources"
-  value       = var.prefix
+output "key_protect_instance_guid" {
+  description = "Key protect instance"
+  value       = module.key_protect_instance.key_protect_guid
 }
 
-output "resource_group_name" {
-  description = "The name of the resource group used"
-  value       = var.resource_group
-}
-
-output "resource_tags" {
-  description = "List of resource tags"
-  value       = var.resource_tags
+output "service_auth_cbr_rules" {
+  description = "Details of rules created"
+  value       = module.service_auth_cbr_rules
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -13,7 +13,7 @@ variable "region" {
 variable "prefix" {
   type        = string
   description = "Prefix to append to all resources created by this example"
-  default     = "complete"
+  default     = "complete-s2s"
 }
 
 variable "resource_group" {
@@ -26,4 +26,10 @@ variable "resource_tags" {
   type        = list(string)
   description = "Optional list of tags to be added to created resources"
   default     = []
+}
+
+variable "enforcement_mode" {
+  type        = string
+  description = "The rule enforcement mode"
+  default     = "report"
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.49.0, < 2.0.0"
+      version = ">= 1.56.1, < 2.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,24 @@
-/********************************************************************
-This file is used to implement the ROOT module.
-*********************************************************************/
+##############################################################################
+# Service To Service Authorization Policies
+##############################################################################
+
+resource "ibm_iam_authorization_policy" "auth_policies" {
+  count                       = length(var.service_map)
+  source_service_name         = var.service_map[count.index].source_service_name
+  target_service_name         = var.service_map[count.index].target_service_name
+  roles                       = var.service_map[count.index].roles
+  description                 = var.service_map[count.index].description
+  source_resource_instance_id = var.service_map[count.index].source_resource_instance_id
+  target_resource_instance_id = var.service_map[count.index].target_resource_instance_id
+  source_resource_group_id    = var.service_map[count.index].source_resource_group_id
+  target_resource_group_id    = var.service_map[count.index].target_resource_group_id
+}
+
+module "cbr_rules" {
+  source                 = "terraform-ibm-modules/cbr/ibm//modules/cbr-service-profile"
+  version                = "1.12.1"
+  target_service_details = var.cbr_target_service_details
+  zone_vpc_crn_list      = var.zone_vpc_crn_list
+  zone_service_ref_list  = var.zone_service_ref_list
+  prefix                 = var.prefix
+}

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -1,12 +1,219 @@
 {
   "path": ".",
-  "variables": {},
-  "outputs": {},
+  "variables": {
+    "cbr_target_service_details": {
+      "name": "cbr_target_service_details",
+      "type": "list(object({\n    target_service_name = string\n    target_rg           = optional(string)\n    enforcement_mode    = string\n    tags                = optional(list(string))\n  }))",
+      "description": "Details of the target service for which the rule has to be created",
+      "default": [],
+      "source": [
+        "module.cbr_rules"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 72
+      }
+    },
+    "prefix": {
+      "name": "prefix",
+      "type": "string",
+      "description": "Prefix to append when creating CBR zones and CBR rules",
+      "default": "serviceprofile",
+      "source": [
+        "module.cbr_rules.module.cbr_rule.ibm_cbr_rule.cbr_rule.description"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 5
+      },
+      "max_length": 300,
+      "matches": "^[\\x20-\\xFE]*$"
+    },
+    "service_map": {
+      "name": "service_map",
+      "type": "list(object({\n    source_service_name         = string\n    target_service_name         = string\n    roles                       = list(string)\n    description                 = optional(string, null)\n    source_resource_instance_id = optional(string, null)\n    target_resource_instance_id = optional(string, null)\n    source_resource_group_id    = optional(string, null)\n    target_resource_group_id    = optional(string, null)\n  }))",
+      "description": "Map of source service and the corresponding target service details",
+      "default": [],
+      "source": [
+        "ibm_iam_authorization_policy.auth_policies.count",
+        "ibm_iam_authorization_policy.auth_policies.description",
+        "ibm_iam_authorization_policy.auth_policies.roles",
+        "ibm_iam_authorization_policy.auth_policies.source_resource_group_id",
+        "ibm_iam_authorization_policy.auth_policies.source_resource_instance_id",
+        "ibm_iam_authorization_policy.auth_policies.source_service_name",
+        "ibm_iam_authorization_policy.auth_policies.target_resource_group_id",
+        "ibm_iam_authorization_policy.auth_policies.target_resource_instance_id",
+        "ibm_iam_authorization_policy.auth_policies.target_service_name"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 11
+      }
+    },
+    "zone_service_ref_list": {
+      "name": "zone_service_ref_list",
+      "type": "list(string)",
+      "description": "Service reference for the zone creation",
+      "default": [],
+      "source": [
+        "module.cbr_rules"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 83
+      }
+    },
+    "zone_vpc_crn_list": {
+      "name": "zone_vpc_crn_list",
+      "type": "list(string)",
+      "description": "VPC CRN for the zones",
+      "default": [],
+      "source": [
+        "module.cbr_rules"
+      ],
+      "pos": {
+        "filename": "variables.tf",
+        "line": 89
+      }
+    }
+  },
+  "outputs": {
+    "auth_policies": {
+      "name": "auth_policies",
+      "description": "Authorizations created",
+      "value": "resource.ibm_iam_authorization_policy.auth_policies",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 10
+      }
+    },
+    "cbr_rules": {
+      "name": "cbr_rules",
+      "description": "CBR Rules created",
+      "value": "module.cbr_rules",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 5
+      }
+    }
+  },
   "required_core": [
     "\u003e= 1.3.0, \u003c1.6.0"
   ],
-  "required_providers": {},
-  "managed_resources": {},
+  "required_providers": {
+    "ibm": {
+      "source": "IBM-Cloud/ibm",
+      "version_constraints": [
+        "\u003e= 1.56.1"
+      ]
+    }
+  },
+  "managed_resources": {
+    "ibm_iam_authorization_policy.auth_policies": {
+      "mode": "managed",
+      "type": "ibm_iam_authorization_policy",
+      "name": "auth_policies",
+      "attributes": {
+        "count": "service_map",
+        "description": "service_map",
+        "roles": "service_map",
+        "source_resource_group_id": "service_map",
+        "source_resource_instance_id": "service_map",
+        "source_service_name": "service_map",
+        "target_resource_group_id": "service_map",
+        "target_resource_instance_id": "service_map",
+        "target_service_name": "service_map"
+      },
+      "provider": {
+        "name": "ibm"
+      },
+      "pos": {
+        "filename": "main.tf",
+        "line": 5
+      }
+    }
+  },
   "data_resources": {},
-  "module_calls": {}
+  "module_calls": {
+    "cbr_rules": {
+      "name": "cbr_rules",
+      "source": "terraform-ibm-modules/cbr/ibm//modules/cbr-service-profile",
+      "version": "1.12.1",
+      "attributes": {
+        "prefix": "prefix",
+        "target_service_details": "cbr_target_service_details",
+        "zone_service_ref_list": "zone_service_ref_list",
+        "zone_vpc_crn_list": "zone_vpc_crn_list"
+      },
+      "managed_resources": {},
+      "data_resources": {
+        "data.ibm_iam_account_settings.iam_account_settings": {
+          "mode": "data",
+          "type": "ibm_iam_account_settings",
+          "name": "iam_account_settings",
+          "provider": {
+            "name": "ibm"
+          },
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/main.tf",
+            "line": 4
+          }
+        }
+      },
+      "outputs": {
+        "rule_crns": {
+          "name": "rule_crns",
+          "description": "CBR rule crn(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 25
+          }
+        },
+        "rule_hrefs": {
+          "name": "rule_hrefs",
+          "description": "CBR rule href(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 30
+          }
+        },
+        "rule_ids": {
+          "name": "rule_ids",
+          "description": "CBR rule id(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 20
+          }
+        },
+        "zone_crns": {
+          "name": "zone_crns",
+          "description": "CBR zone crn(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 10
+          }
+        },
+        "zone_hrefs": {
+          "name": "zone_hrefs",
+          "description": "CBR zone href(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 15
+          }
+        },
+        "zone_ids": {
+          "name": "zone_ids",
+          "description": "CBR zone resource instance id(s)",
+          "pos": {
+            "filename": ".terraform/modules/cbr_rules/modules/cbr-service-profile/outputs.tf",
+            "line": 5
+          }
+        }
+      },
+      "pos": {
+        "filename": "main.tf",
+        "line": 17
+      }
+    }
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,14 @@
 # Outputs
 ########################################################################################################################
 
-#output "myoutput" {
-#  description = "Description of my output"
-#  value       = "value"
-#}
+output "cbr_rules" {
+  description = "CBR Rules created"
+  value       = module.cbr_rules
+}
+
+output "auth_policies" {
+  description = "Authorizations created"
+  value       = resource.ibm_iam_authorization_policy.auth_policies
+}
+
+##############################################################################

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -5,12 +5,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
+
+const basicExampleTerraformDir = "examples/basic"
 
 func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "mod-template-basic", "examples/basic")
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+		Testing:      t,
+		TerraformDir: basicExampleTerraformDir,
+		Prefix:       "s2s-basic",
+	})
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -8,16 +8,15 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
-// Use existing resource group
-const resourceGroup = "geretain-test-resources"
 const completeExampleDir = "examples/complete"
 
 func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptions {
+	// Allow tests to create their own resource group
+	// This is to avoid conflicts on CBR rules when running in parallel
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  dir,
-		Prefix:        prefix,
-		ResourceGroup: resourceGroup,
+		Testing:      t,
+		TerraformDir: dir,
+		Prefix:       prefix,
 	})
 	return options
 }
@@ -25,7 +24,7 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 func TestRunCompleteExample(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "mod-template", completeExampleDir)
+	options := setupOptions(t, "s2s", completeExampleDir)
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
@@ -35,7 +34,7 @@ func TestRunCompleteExample(t *testing.T) {
 func TestRunUpgradeExample(t *testing.T) {
 	t.Parallel()
 
-	options := setupOptions(t, "mod-template-upg", completeExampleDir)
+	options := setupOptions(t, "s2s-upg", completeExampleDir)
 
 	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {

--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,92 @@
 # Input Variables
 ########################################################################################################################
 
-#variable "my_variable" {
-#  type        = string
-#  description = "A description of my variable"
-#  default     = "default_value"
-#}
+variable "prefix" {
+  type        = string
+  description = "Prefix to append when creating CBR zones and CBR rules"
+  default     = null
+}
+
+variable "service_map" {
+  description = "Map of source service and the corresponding target service details"
+  type = list(object({
+    source_service_name         = string
+    target_service_name         = string
+    roles                       = list(string)
+    description                 = optional(string, null)
+    source_resource_instance_id = optional(string, null)
+    target_resource_instance_id = optional(string, null)
+    source_resource_group_id    = optional(string, null)
+    target_resource_group_id    = optional(string, null)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for service in var.service_map :
+      contains(["iam-groups", "iam-access-management", "iam-identity",
+        "user-management", "cloud-object-storage", "codeengine",
+        "container-registry", "databases-for-cassandra",
+        "databases-for-enterprisedb", "databases-for-elasticsearch",
+        "databases-for-etcd", "databases-for-mongodb",
+        "databases-for-mysql", "databases-for-postgresql", "databases-for-redis",
+        "directlink", "dns-svcs", "messagehub", "kms", "containers-kubernetes",
+        "messages-for-rabbitmq", "secrets-manager", "transit", "is",
+        "schematics", "apprapp", "event-notifications", "compliance", "kms", "atracker", "sql-query", "hs-crypto", "server-protect"],
+      service.source_service_name) &&
+      contains(["iam-groups", "iam-access-management", "iam-identity",
+        "user-management", "cloud-object-storage", "codeengine",
+        "container-registry", "databases-for-cassandra",
+        "databases-for-enterprisedb", "databases-for-elasticsearch",
+        "databases-for-etcd", "databases-for-mongodb",
+        "databases-for-mysql", "databases-for-postgresql", "databases-for-redis",
+        "directlink", "dns-svcs", "messagehub", "kms", "containers-kubernetes",
+        "messages-for-rabbitmq", "secrets-manager", "transit", "is",
+        "schematics", "apprapp", "event-notifications", "compliance",
+        "kms", "internet-svcs", "atracker", "sql-query", "hs-crypto", "server-protect"],
+      service.target_service_name)
+    ])
+    error_message = "Provide a valid service for auth policy creation"
+  }
+
+  validation {
+    condition = alltrue([
+      for service in var.service_map :
+      ((service.source_resource_instance_id != null && service.source_resource_group_id == null) ||
+      (service.source_resource_instance_id == null && service.source_resource_group_id != null))
+    ])
+    error_message = "source_resource_instance_id and source_resource_group_id are mutually exclusive, please only provide one of the values"
+  }
+
+  validation {
+    condition = alltrue([
+      for service in var.service_map :
+      ((service.target_resource_instance_id != null && service.target_resource_group_id == null) ||
+      (service.target_resource_instance_id == null && service.target_resource_group_id != null))
+    ])
+    error_message = "target_resource_instance_id and target_resource_group_id are mutually exlusive, please only provide one of the values"
+  }
+}
+
+variable "cbr_target_service_details" {
+  type = list(object({
+    target_service_name = string
+    target_rg           = optional(string)
+    enforcement_mode    = string
+    tags                = optional(list(string))
+  }))
+  description = "Details of the target service for which the rule has to be created"
+  default     = []
+}
+
+variable "zone_service_ref_list" {
+  type        = list(string)
+  default     = []
+  description = "Service reference for the zone creation"
+}
+
+variable "zone_vpc_crn_list" {
+  type        = list(string)
+  default     = []
+  description = "VPC CRN for the zones"
+}

--- a/version.tf
+++ b/version.tf
@@ -1,12 +1,11 @@
 terraform {
   required_version = ">= 1.3.0, <1.6.0"
-  # If your module requires any terraform providers, uncomment the "required_providers" section below and add all required providers.
   # Each required provider's version should be a flexible range to future proof the module's usage with upcoming minor and patch versions.
-
-  #  required_providers {
-  #    ibm = {
-  #      source  = "IBM-Cloud/ibm"
-  #      version = ">= 1.49.0, < 2.0.0"
-  #    }
-  #  }
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+      # Use "greater than or equal to" range in modules
+      version = ">= 1.56.1"
+    }
+  }
 }


### PR DESCRIPTION
### Description
Initial module implementation for the Service to Service authorization module.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

module implementation with capability to create service to service authorization policies, cbr rules, and ability to scope those rules to a cbr zone

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
